### PR TITLE
Install kmod in image to get zstd module support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM=alpine:3.18
 
 FROM $BUILD_FROM
 
-RUN apk --update --no-cache add bash nfs-utils libcap-utils && \
+RUN apk --update --no-cache add kmod bash nfs-utils libcap-utils && \
     # remove the default config files
     rm -v /etc/idmapd.conf /etc/exports
 


### PR DESCRIPTION
Running on an Ubuntu 24.04 host, the nfs kernel modules are zstd compressed. The modprobe that ships with alpine does not support zstd compressed modules and thus the image fails to start.

```
==================================================================
      SETTING UP ...
==================================================================
----> kernel module nfsd is missing
----> attempting to load kernel module nfsd
insmod /lib/modules/6.8.0-60-generic/kernel/fs/nfs_common/nfs_acl.ko.zst
modprobe: ERROR: could not insert 'nfsd': Exec format error
---->
----> ERROR: unable to dynamically load kernel module nfsd. try modprobe nfsd on the Docker host
---->
```

If I set this as my entry command everything starts up just fine.

```
          command: ["/bin/sh","-c"]
          args:
            - |
              apk add --no-cache kmod \
              && exec /usr/local/bin/entrypoint.sh
```

See this built at ghcr.io/adepssimius/nfs-server:latest